### PR TITLE
Added embed link to GraphQL

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -30,11 +30,15 @@ export const sourceNodes = async (
   const getEpisodeId = (guid: string) => `anchor-episode-${guid}`;
 
   for (const p of anchorData.items) {
-    const episodeDigest = JSON.stringify(p);
-    createNode({
+    const episodeData = {
       ...p,
+      embedLink: p.link.replace(/\/episodes/g, "/embed/episodes")
+    }
+    const episodeDigest = JSON.stringify(episodeData);
+    createNode({
+      ...episodeData,
       // meta information for the node
-      id: getEpisodeId(p.guid),
+      id: getEpisodeId(episodeData.guid),
       parent: null,
       children: [],
       internal: {


### PR DESCRIPTION
The Anchor RSS feed doesn't provide a URL that works with their embeddable audio player. I've used a simple RegEx formula on the episode link to generate that URL and add it to GraphQL as "embedLink".

While the audio file url IS present in the RSS feed, using the embeddable audio player is probably a more common use case than implementing custom solutions.